### PR TITLE
feat: allow to set the optimization target

### DIFF
--- a/golpa.go
+++ b/golpa.go
@@ -444,3 +444,12 @@ func (model *Model) ExportLP() (string, error) {
 
 	return buf.String(), nil
 }
+
+// SetTarget sets the optimization target for the model.
+// The solver will return early if this target is reached.
+func (model *Model) SetTarget(target float64) {
+	model.mu.RLock()
+	defer model.mu.RUnlock()
+
+	C.set_break_at_value(model.prob, C.double(target))
+}

--- a/result.go
+++ b/result.go
@@ -40,7 +40,7 @@ const (
 type SolveError C.int
 
 const (
-	ErrBranchCutBreak   = SolveError(C.PROCBREAK) // should not be seen: we don't use set_break_at_first/set_break_at_value
+	ErrBranchCutBreak   = SolveError(C.PROCBREAK)
 	ErrBranchCutFail    = SolveError(C.PROCFAIL)
 	ErrFeasibleFound    = SolveError(C.FEASFOUND)
 	ErrModelDegenerate  = SolveError(C.DEGENERATE)


### PR DESCRIPTION
This adds the option to set an optimization target.

I tried to adapt the assumptions about early returns, but I am not sure if the comment is the only place to be involved here.